### PR TITLE
Hazelcast preparations

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/pid/PidGenerator.scala
+++ b/src/main/scala/nl/knaw/dans/easy/pid/PidGenerator.scala
@@ -15,23 +15,21 @@
  */
 package nl.knaw.dans.easy.pid
 
+import java.io.File
 import java.lang.Math.pow
+
+import com.typesafe.config.Config
+
 import scala.util.Try
-import scala.util.Failure
-import scala.util.Success
-import scala.util.Success
-import scala.util.Success
-import scala.util.Success
 
 case class PidGenerator(seed: SeedStorage, firstSeed: Long, format: Long => String) {
-  def next(): Try[String] =
-    seed.calculateAndPersist(getNextPidNumber).map(format(_))
 
+  def next(): Try[String] = seed.calculateAndPersist(getNextPidNumber).map(format(_))
 
   /**
    * Generates a new PID number from a provided seed. The PID number is then formatted as a DOI or a URN.
    * The PID number also serves as the seed for the next time this function is called (for the same type
-   * of identifier). The sequence of PID numbers will go through all the numbers between 0 and 2^31 - 1,
+   * of identifier). The sequence of PID numbers will go through all the numbers between 0 and 2^31 - 1^,
    * and then return to the first seed. See for proof of this:
    * <a href="http://en.wikipedia.org/wiki/Linear_congruential_generator">this page</a>
    */
@@ -42,5 +40,29 @@ case class PidGenerator(seed: SeedStorage, firstSeed: Long, format: Long => Stri
     val newSeed = (seed * factor + increment) % modulo
     if (newSeed == firstSeed) None
     else Some(newSeed)
+  }
+}
+
+object PidGenerator {
+  private def generate(key: String, length: Int, conf: Config, home: File, illegalChars: Map[Char, Char]): PidGenerator = {
+    val firstSeed = conf.getLong(s"types.$key.firstSeed")
+    val storage = DbBasedSeedStorage(key, firstSeed, new File(home, "cfg/hibernate.conf.xml"))
+    val formatter = format(
+      prefix = conf.getString(s"types.$key.namespace"),
+      radix = MAX_RADIX - illegalChars.size,
+      len = length,
+      charMap = illegalChars,
+      dashPos = conf.getInt(s"types.$key.dashPosition")
+    )
+
+    PidGenerator(storage, firstSeed, formatter)
+  }
+
+  def urnGenerator(conf: Config, home: File): PidGenerator = {
+    generate("urn", 6, conf, home, Map.empty)
+  }
+
+  def doiGenerator(conf: Config, home: File): PidGenerator = {
+    generate("doi", 7, conf, home, Map('0' -> 'z', 'o' -> 'y', '1' -> 'x', 'i' -> 'w', 'l' -> 'v'))
   }
 }

--- a/src/main/scala/nl/knaw/dans/easy/pid/SeedStorage.scala
+++ b/src/main/scala/nl/knaw/dans/easy/pid/SeedStorage.scala
@@ -26,7 +26,6 @@ import org.hibernate.exception.GenericJDBCException
 import org.postgresql.util.PSQLException
 import org.slf4j.LoggerFactory
 
-import scala.annotation.tailrec
 import scala.beans.BeanProperty
 import scala.util.{Failure, Success, Try}
 
@@ -68,7 +67,7 @@ case class DbBasedSeedStorage(key: String, first: Long, hibernateConfig: File) e
 
   override def calculateAndPersist(f: Long => Option[Long]): Try[Long] = {
 
-    @tailrec
+    //@tailrec
     def iterWhileRestarting(timeout: Int = 0, maxRetry: Int = 3): Try[Long] = {
       val session = sessionFactory.getCurrentSession
       session.beginTransaction()

--- a/src/main/scala/nl/knaw/dans/easy/pid/SeedStorage.scala
+++ b/src/main/scala/nl/knaw/dans/easy/pid/SeedStorage.scala
@@ -51,7 +51,7 @@ object Seed {
   def create(pidType: String, value: Long) = {
     val seed = new Seed
     seed.pidType = pidType
-    seed.value = next
+    seed.value = value
 
     seed
   }

--- a/src/main/scala/nl/knaw/dans/easy/pid/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/pid/package.scala
@@ -41,5 +41,8 @@ package object pid {
     padWithZeroes(java.lang.Long.toString(pid, radix).toLowerCase).map { c => illegalCharMap.getOrElse(c, c) }
   }
 
-  def insertDashAt(i: Int)(s: String): String = s.substring(0, i) + "-" + s.substring(i)
+  def insertDashAt(i: Int)(s: String): String = {
+    val (prefix, suffix) = s.splitAt(i)
+    s"$prefix-$suffix"
+  }
 }

--- a/src/main/scala/nl/knaw/dans/easy/pid/package.scala
+++ b/src/main/scala/nl/knaw/dans/easy/pid/package.scala
@@ -15,10 +15,6 @@
  */
 package nl.knaw.dans.easy
 
-import Math.pow
-import java.io.File
-import com.typesafe.config.ConfigFactory
-
 package object pid {
   val MAX_RADIX = 36
 
@@ -35,7 +31,7 @@ package object pid {
    *   should therefore be sufficiently small to have enough unused chars.
    * @param dashPos position to insert a dash for readability
    * @param pid the PID number to format
-   * @returns the formatted PID 
+   * @return the formatted PID
    */
   def format(prefix: String, radix: Int, len: Int, charMap: Map[Char, Char], dashPos: Int)(pid: Long): String =
     prefix + insertDashAt(dashPos)(convertToString(pid, radix, len, charMap))

--- a/src/test/scala/nl/knaw/dans/easy/pid/PidPackageSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/pid/PidPackageSpec.scala
@@ -15,36 +15,31 @@
  */
 package nl.knaw.dans.easy.pid
 
-import org.scalatest.Matchers
-import org.scalatest.PropSpec
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import Math.pow
 import org.scalacheck.Gen
+import org.scalatest.{Matchers, PropSpec}
+import org.scalatest.prop.GeneratorDrivenPropertyChecks
 
 class PidPackageSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
 
   property("Formatted PID starts with configured prefix") {
-    forAll(Gen.posNum[Long],
-      Gen.alphaStr,
-      Gen.choose(2, 36),
-      Gen.choose(5, 10)) {
-        (pid: Long, prefix: String, radix: Int, len: Int) =>
-          val result = format(prefix,
-            radix,
-            len,
-            Map[Char, Char](),
-            3)(pid)
-          result should startWith(prefix)
-      }
+    forAll(Gen.posNum[Long], Gen.alphaStr, Gen.choose(2, 36), Gen.choose(5, 10)) {
+      (pid: Long, prefix: String, radix: Int, len: Int) =>
+        val result = format(prefix,
+          radix,
+          len,
+          Map[Char, Char](),
+          3)(pid)
+        result should startWith (prefix)
+    }
   }
-  
+
   // TODO: Test more properties of format 
-  
+
   property("insertDashAt inserts dash at given index") {
     forAll(Gen.alphaStr, Gen.posNum[Int]) { (s: String, i: Int) =>
       whenever(i < s.length) {
         val result = insertDashAt(i)(s)
-        result(i) should be('-')
+        result(i) shouldBe '-'
       }
     }
   }


### PR DESCRIPTION
**fixes EASY-1115**

This PR is a preparation for the integration of Hazelcast into the pid-generation service.
#### When applied it will
- `PidGenerator` creation in companion object rather than in `PidService`, such that I can get a generator for Hazelcast in the future in a simple way.
- `Some`/`None` pattern matching refactored to higher-order functions
- better implementation for `insertDashAt`
- `iterWhileRestarting` also sleeps for 5000ms after the first try
- cleanup imports and code formatting
#### Where should the reviewer @DANS-KNAW/easy start?

`PidGenerator` and `PidService`
#### How should this be manually tested?
- checkout these changes
- run `mvnci`
- deploy the role on deasy
- run `curl --data "type=urn" deasy.dans.knaw.nl:8082/pids/` and `curl --data "type=doi" deasy.dans.knaw.nl:8082/pids/` to get an `urn` and `doi` respectively.
