### PR TITLE
daemon init fix

### DIFF
--- a/src/main/assembly/dist/bin/easy-pid-generator
+++ b/src/main/assembly/dist/bin/easy-pid-generator
@@ -21,7 +21,7 @@ USER="easy_pid_generator"
 PID="/var/run/$NAME.pid"
 OUTFILE="/var/log/$NAME/$NAME.out"
 ERRFILE="/var/log/$NAME/$NAME.err"
-WAIT_TIME=20
+WAIT_TIME=60
 
 jsvc_exec()
 {
@@ -34,7 +34,7 @@ jsvc_exec()
 start_jsvc_exec()
 {
     jsvc_exec
-    if [[ $? == 0 ]]; then # if start is successful
+    if [[ $? == 0 ]]; then # start is successful
         echo "$NAME has started."
     else
         echo "$NAME did not start successfully (exit code: $?)."
@@ -44,7 +44,7 @@ start_jsvc_exec()
 stop_jsvc_exec()
 {
     jsvc_exec "-stop"
-    if [[ $? == 0 ]]; then # if stop is successful
+    if [[ $? == 0 ]]; then # stop is successful
         echo "$NAME has stopped."
     else
         echo "$NAME did not stop successfully (exit code: $?)".
@@ -55,10 +55,10 @@ restart_jsvc_exec()
 {
     echo "Restarting $NAME ..."
     jsvc_exec "-stop"
-    if [[ $? == 0 ]]; then # if stop is successful
+    if [[ $? == 0 ]]; then # stop is successful
         echo "$NAME has stopped, starting again ..."
         jsvc_exec
-        if [[ $? == 0 ]]; then # if start is successful
+        if [[ $? == 0 ]]; then # start is successful
             echo "$NAME has restarted."
         else
             echo "$NAME did not start successfully (exit code: $?)."
@@ -70,7 +70,7 @@ restart_jsvc_exec()
 
 case "$1" in
     start)
-        if [ -f "$PID" ]; then # if service is running
+        if [ -f "$PID" ]; then # service is running
             echo "$NAME is already running, no action taken."
             exit 1
         else
@@ -79,7 +79,7 @@ case "$1" in
         fi
     ;;
     stop)
-        if [ -f "$PID" ]; then # if service is running
+        if [ -f "$PID" ]; then # service is running
             echo "Stopping $NAME ..."
             stop_jsvc_exec
         else
@@ -88,13 +88,11 @@ case "$1" in
         fi
     ;;
     restart)
-        if [ -f "$PID" ]; then # if service is running
+        if [ -f "$PID" ]; then # service is running
             restart_jsvc_exec
         else
             echo "$NAME is not running, just starting ..."
             start_jsvc_exec
-#            echo "$NAME is not running, no action taken"
-#            exit 1
         fi
     ;;
     status)

--- a/src/main/assembly/dist/bin/easy-pid-generator
+++ b/src/main/assembly/dist/bin/easy-pid-generator
@@ -14,7 +14,7 @@ NAME="easy-pid-generator"
 EXEC="/usr/bin/jsvc"
 APPHOME="/opt/easy-pid-generator"
 JAVA_HOME="/usr/lib/jvm/jre"
-CLASSPATH="$APPHOME/bin/$NAME.jar:`echo $APPHOME/lib/*.jar | sed 's/ /:/g'`"
+CLASSPATH="$APPHOME/bin/$NAME.jar:`echo ${APPHOME}/lib/*.jar | sed 's/ /:/g'`"
 CLASS="nl.knaw.dans.easy.pid.ServiceStarter"
 ARGS=""
 USER="easy_pid_generator"
@@ -25,10 +25,10 @@ WAIT_TIME=20
 
 jsvc_exec()
 {
-    cd $APPHOME
-    $EXEC -home $JAVA_HOME -cp $CLASSPATH -user $USER -outfile $OUTFILE -errfile $ERRFILE -pidfile $PID -wait $WAIT_TIME \
-          -Dapp.home=$APPHOME -Dconfig.file=$APPHOME/cfg/application.conf \
-          -Dlogback.configurationFile=$APPHOME/cfg/logback.xml $1 $CLASS $ARGS
+    cd ${APPHOME}
+    ${EXEC} -home ${JAVA_HOME} -cp ${CLASSPATH} -user ${USER} -outfile ${OUTFILE} -errfile ${ERRFILE} -pidfile ${PID} -wait ${WAIT_TIME} \
+          -Dapp.home=${APPHOME} -Dconfig.file=${APPHOME}/cfg/application.conf \
+          -Dlogback.configurationFile=${APPHOME}/cfg/logback.xml $1 ${CLASS} ${ARGS}
 }
 
 start_jsvc_exec()

--- a/src/main/assembly/dist/bin/easy-pid-generator
+++ b/src/main/assembly/dist/bin/easy-pid-generator
@@ -21,11 +21,12 @@ USER="easy_pid_generator"
 PID="/var/run/$NAME.pid"
 OUTFILE="/var/log/$NAME/$NAME.out"
 ERRFILE="/var/log/$NAME/$NAME.err"
+WAIT_TIME=20
 
 jsvc_exec()
 {
     cd $APPHOME
-    $EXEC -home $JAVA_HOME -cp $CLASSPATH -user $USER -outfile $OUTFILE -errfile $ERRFILE -pidfile $PID -wait 20 \
+    $EXEC -home $JAVA_HOME -cp $CLASSPATH -user $USER -outfile $OUTFILE -errfile $ERRFILE -pidfile $PID -wait $WAIT_TIME \
           -Dapp.home=$APPHOME -Dconfig.file=$APPHOME/cfg/application.conf \
           -Dlogback.configurationFile=$APPHOME/cfg/logback.xml $1 $CLASS $ARGS
 }
@@ -34,13 +35,10 @@ start_jsvc_exec()
 {
     echo "Starting $NAME ..."
     jsvc_exec
-
-    local exitcode=$?
-
-    if [[ $exitcode == 0 ]]; then
+    if [[ $? == 0 ]]; then
         echo "$NAME has started."
     else
-        echo "$NAME did not start successfully. exit code is $exitcode"
+        echo "$NAME did not start successfully (exit code: $?)"
     fi
 }
 
@@ -48,13 +46,10 @@ stop_jsvc_exec()
 {
     echo "Stopping $NAME ..."
     jsvc_exec "-stop"
-
-    local exitcode=$?
-
-    if [[ $exitcode == 0 ]]; then
+    if [[ $? == 0 ]]; then
         echo "$NAME has stopped."
     else
-        echo "$NAME did not stop successfully. exit code is $exitcode"
+        echo "$NAME did not stop successfully (exit code: $?)"
     fi
 }
 

--- a/src/main/assembly/dist/bin/easy-pid-generator
+++ b/src/main/assembly/dist/bin/easy-pid-generator
@@ -33,23 +33,21 @@ jsvc_exec()
 
 start_jsvc_exec()
 {
-    echo "Starting $NAME ..."
     jsvc_exec
     if [[ $? == 0 ]]; then # if start is successful
         echo "$NAME has started."
     else
-        echo "$NAME did not start successfully (exit code: $?)"
+        echo "$NAME did not start successfully (exit code: $?)."
     fi
 }
 
 stop_jsvc_exec()
 {
-    echo "Stopping $NAME ..."
     jsvc_exec "-stop"
     if [[ $? == 0 ]]; then # if stop is successful
         echo "$NAME has stopped."
     else
-        echo "$NAME did not stop successfully (exit code: $?)"
+        echo "$NAME did not stop successfully (exit code: $?)".
     fi
 }
 
@@ -58,31 +56,34 @@ restart_jsvc_exec()
     echo "Restarting $NAME ..."
     jsvc_exec "-stop"
     if [[ $? == 0 ]]; then # if stop is successful
+        echo "$NAME has stopped, starting again ..."
         jsvc_exec
         if [[ $? == 0 ]]; then # if start is successful
             echo "$NAME has restarted."
         else
-            echo "$NAME did not start successfully (exit code: $?)"
+            echo "$NAME did not start successfully (exit code: $?)."
         fi
     else
-        echo "$NAME did not stop successfully (exit code: $?)"
+        echo "$NAME did not stop successfully (exit code: $?)."
     fi
 }
 
 case "$1" in
     start)
         if [ -f "$PID" ]; then # if service is running
-            echo "$NAME is already running, no action taken"
+            echo "$NAME is already running, no action taken."
             exit 1
         else
+            echo "Starting $NAME ..."
             start_jsvc_exec
         fi
     ;;
     stop)
         if [ -f "$PID" ]; then # if service is running
+            echo "Stopping $NAME ..."
             stop_jsvc_exec
         else
-            echo "$NAME is already running, no action taken"
+            echo "$NAME is not running, no action taken."
             exit 1
         fi
     ;;
@@ -90,15 +91,17 @@ case "$1" in
         if [ -f "$PID" ]; then # if service is running
             restart_jsvc_exec
         else
-            echo "$NAME is not running, no action taken"
-            exit 1
+            echo "$NAME is not running, just starting ..."
+            start_jsvc_exec
+#            echo "$NAME is not running, no action taken"
+#            exit 1
         fi
     ;;
     status)
         if [ -f "$PID" ]; then # if service is running
-            echo "$NAME (pid `cat $PID`) is running"
+            echo "$NAME (pid `cat $PID`) is running."
         else
-            echo "$NAME is stopped"
+            echo "$NAME is stopped."
         fi
     ;;
     *)

--- a/src/main/assembly/dist/bin/easy-pid-generator
+++ b/src/main/assembly/dist/bin/easy-pid-generator
@@ -35,7 +35,7 @@ start_jsvc_exec()
 {
     echo "Starting $NAME ..."
     jsvc_exec
-    if [[ $? == 0 ]]; then
+    if [[ $? == 0 ]]; then # if start is successful
         echo "$NAME has started."
     else
         echo "$NAME did not start successfully (exit code: $?)"
@@ -46,8 +46,24 @@ stop_jsvc_exec()
 {
     echo "Stopping $NAME ..."
     jsvc_exec "-stop"
-    if [[ $? == 0 ]]; then
+    if [[ $? == 0 ]]; then # if stop is successful
         echo "$NAME has stopped."
+    else
+        echo "$NAME did not stop successfully (exit code: $?)"
+    fi
+}
+
+restart_jsvc_exec()
+{
+    echo "Restarting $NAME ..."
+    jsvc_exec "-stop"
+    if [[ $? == 0 ]]; then # if stop is successful
+        jsvc_exec
+        if [[ $? == 0 ]]; then # if start is successful
+            echo "$NAME has restarted."
+        else
+            echo "$NAME did not start successfully (exit code: $?)"
+        fi
     else
         echo "$NAME did not stop successfully (exit code: $?)"
     fi
@@ -55,36 +71,38 @@ stop_jsvc_exec()
 
 case "$1" in
     start)
-        if [ -f "$PID" ]; then
+        if [ -f "$PID" ]; then # if service is running
+            echo "$NAME is already running, no action taken"
+            exit 1
+        else
             start_jsvc_exec
+        fi
+    ;;
+    stop)
+        if [ -f "$PID" ]; then # if service is running
+            stop_jsvc_exec
         else
             echo "$NAME is already running, no action taken"
             exit 1
         fi
     ;;
-    stop)
-        stop_jsvc_exec
-    ;;
     restart)
-        if [ -f "$PID" ]; then
-            echo "Restarting $NAME ..."
-            jsvc_exec "-stop"
-            jsvc_exec
-            echo "$NAME has restarted."
+        if [ -f "$PID" ]; then # if service is running
+            restart_jsvc_exec
         else
             echo "$NAME is not running, no action taken"
             exit 1
         fi
     ;;
     status)
-        if [ -f "$PID" ]
-        then
+        if [ -f "$PID" ]; then # if service is running
             echo "$NAME (pid `cat $PID`) is running"
         else
             echo "$NAME is stopped"
         fi
     ;;
     *)
-    echo "Usage: sudo service $NAME {start|stop|restart|status}" >&2
-    exit 3
+        echo "Usage: sudo service $NAME {start|stop|restart|status}" >&2
+        exit 3
+    ;;
 esac

--- a/src/main/assembly/dist/bin/easy-pid-generator
+++ b/src/main/assembly/dist/bin/easy-pid-generator
@@ -15,7 +15,7 @@ EXEC="/usr/bin/jsvc"
 APPHOME="/opt/easy-pid-generator"
 JAVA_HOME="/usr/lib/jvm/jre"
 CLASSPATH="$APPHOME/bin/$NAME.jar:`echo $APPHOME/lib/*.jar | sed 's/ /:/g'`"
-CLASS="nl.knaw.dans.easy.pid.PidServiceStarter"
+CLASS="nl.knaw.dans.easy.pid.ServiceStarter"
 ARGS=""
 USER="easy_pid_generator"
 PID="/var/run/$NAME.pid"
@@ -25,21 +25,45 @@ ERRFILE="/var/log/$NAME/$NAME.err"
 jsvc_exec()
 {
     cd $APPHOME
-    $EXEC -home $JAVA_HOME -cp $CLASSPATH -user $USER -outfile $OUTFILE -errfile $ERRFILE -pidfile $PID \
+    $EXEC -home $JAVA_HOME -cp $CLASSPATH -user $USER -outfile $OUTFILE -errfile $ERRFILE -pidfile $PID -wait 20 \
           -Dapp.home=$APPHOME -Dconfig.file=$APPHOME/cfg/application.conf \
           -Dlogback.configurationFile=$APPHOME/cfg/logback.xml $1 $CLASS $ARGS
 }
 
+start_jsvc_exec()
+{
+    echo "Starting $NAME ..."
+    jsvc_exec
+
+    local exitcode=$?
+
+    if [[ $exitcode == 0 ]]; then
+        echo "$NAME has started."
+    else
+        echo "$NAME did not start successfully. exit code is $exitcode"
+    fi
+}
+
+stop_jsvc_exec()
+{
+    echo "Stopping $NAME ..."
+    jsvc_exec "-stop"
+
+    local exitcode=$?
+
+    if [[ $exitcode == 0 ]]; then
+        echo "$NAME has stopped."
+    else
+        echo "$NAME did not stop successfully. exit code is $exitcode"
+    fi
+}
+
 case "$1" in
     start)
-        echo "Starting $NAME ..."
-        jsvc_exec
-        echo "$NAME has started."
+        start_jsvc_exec
     ;;
     stop)
-        echo "Stopping $NAME ..."
-        jsvc_exec "-stop"
-        echo "$NAME has stopped."
+        stop_jsvc_exec
     ;;
     restart)
         if [ -f "$PID" ]; then

--- a/src/main/assembly/dist/bin/easy-pid-generator
+++ b/src/main/assembly/dist/bin/easy-pid-generator
@@ -55,7 +55,12 @@ stop_jsvc_exec()
 
 case "$1" in
     start)
-        start_jsvc_exec
+        if [ -f "$PID" ]; then
+            start_jsvc_exec
+        else
+            echo "$NAME is already running, no action taken"
+            exit 1
+        fi
     ;;
     stop)
         stop_jsvc_exec

--- a/src/main/scala/nl/knaw/dans/easy/pid/ServiceStarter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/pid/ServiceStarter.scala
@@ -27,7 +27,7 @@ class ServiceStarter extends Daemon with SettingsParser {
   override def init(ctx: DaemonContext): Unit = {
     log = LoggerFactory.getLogger(getClass)
 
-    log.info("Initializing service ...")
+    log.info("Initializing service...")
 
     implicit val settings = getSettings
     service = settings.mode match {
@@ -36,17 +36,17 @@ class ServiceStarter extends Daemon with SettingsParser {
       case unknown => throw new IllegalArgumentException(s"Invalid mode: $unknown. Valid modes are 'rest', 'hazelcast'")
     }
 
-    log.info("Service initialized ...")
+    log.info("Service initialized.")
   }
 
   override def start(): Unit = {
-    log.info("Starting service ...")
+    log.info("Starting service...")
     service.start()
-    log.info("Service started ...")
+    log.info("Service started.")
   }
 
   override def stop(): Unit = {
-    log.info("Stopping service ...")
+    log.info("Stopping service...")
     service.stop()
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/pid/ServiceStarter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/pid/ServiceStarter.scala
@@ -18,14 +18,14 @@ package nl.knaw.dans.easy.pid
 import nl.knaw.dans.easy.pid.microservice.HazelcastService
 import nl.knaw.dans.easy.pid.rest.RestService
 import org.apache.commons.daemon.{Daemon, DaemonContext}
-import org.slf4j.LoggerFactory
+import org.slf4j.{Logger, LoggerFactory}
 
-class PidServiceStarter extends Daemon with SettingsParser {
-  val log = LoggerFactory.getLogger(getClass)
+class ServiceStarter extends Daemon with SettingsParser {
+  var log: Logger = _
   var service: Service = _
 
   override def init(ctx: DaemonContext): Unit = {
-    log.info("Initializing service ...")
+    log = LoggerFactory.getLogger(getClass)
 
     implicit val settings = getSettings
     service = settings.mode match {
@@ -33,6 +33,8 @@ class PidServiceStarter extends Daemon with SettingsParser {
       case Hazelcast => new HazelcastService
       case unknown => throw new IllegalArgumentException(s"Invalid mode: $unknown. Valid modes are 'rest', 'hazelcast'")
     }
+
+    log.info("Service initialized ...")
   }
 
   override def start(): Unit = {

--- a/src/main/scala/nl/knaw/dans/easy/pid/ServiceStarter.scala
+++ b/src/main/scala/nl/knaw/dans/easy/pid/ServiceStarter.scala
@@ -27,6 +27,8 @@ class ServiceStarter extends Daemon with SettingsParser {
   override def init(ctx: DaemonContext): Unit = {
     log = LoggerFactory.getLogger(getClass)
 
+    log.info("Initializing service ...")
+
     implicit val settings = getSettings
     service = settings.mode match {
       case Rest => new RestService
@@ -40,6 +42,7 @@ class ServiceStarter extends Daemon with SettingsParser {
   override def start(): Unit = {
     log.info("Starting service ...")
     service.start()
+    log.info("Service started ...")
   }
 
   override def stop(): Unit = {

--- a/src/main/scala/nl/knaw/dans/easy/pid/microservice/HazelcastService.scala
+++ b/src/main/scala/nl/knaw/dans/easy/pid/microservice/HazelcastService.scala
@@ -26,8 +26,7 @@ import org.slf4j.LoggerFactory
 
 class HazelcastService(implicit settings: Settings) extends Service {
   val log = LoggerFactory.getLogger(getClass)
-
-  log.info("Initializing pid-generator service ...")
+  log.info("Initializing Hazelcast pid-generator service ...")
 
   val hzConf = new ClientConfig()
   serialization.Defaults.register(hzConf.getSerializationConfig)
@@ -40,7 +39,7 @@ class HazelcastService(implicit settings: Settings) extends Service {
   )
 
   override def start(): Unit = {
-    log.info("Starting pid-generator service ...")
+    log.info("Starting Hazelcast pid-generator service ...")
 
     service.run()
       .doOnError(e => log.error(s"an error occured in the PID service: ${e.getClass.getSimpleName} - ${e.getMessage}", e))
@@ -48,14 +47,14 @@ class HazelcastService(implicit settings: Settings) extends Service {
   }
 
   override def stop(): Unit = {
-    log.info("Stopping pid-generator service ...")
+    log.info("Stopping Hazelcast pid-generator service ...")
     service.stop()
   }
 
   override def destroy(): Unit = {
     service.awaitTermination()
     hz.shutdown()
-    log.info("Service pid-generator stopped.")
+    log.info("Service Hazelcast pid-generator stopped.")
   }
 }
 

--- a/src/main/scala/nl/knaw/dans/easy/pid/microservice/HazelcastService.scala
+++ b/src/main/scala/nl/knaw/dans/easy/pid/microservice/HazelcastService.scala
@@ -39,7 +39,7 @@ class HazelcastService(implicit settings: Settings) extends Service {
   )
 
   override def start(): Unit = {
-    log.info("Starting Hazelcast pid-generator service ...")
+    log.info("Starting Hazelcast pid-generator service...")
 
     service.run()
       .doOnError(e => log.error(s"an error occured in the PID service: ${e.getClass.getSimpleName} - ${e.getMessage}", e))
@@ -47,7 +47,7 @@ class HazelcastService(implicit settings: Settings) extends Service {
   }
 
   override def stop(): Unit = {
-    log.info("Stopping Hazelcast pid-generator service ...")
+    log.info("Stopping Hazelcast pid-generator service...")
     service.stop()
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/pid/rest/PidRestService.scala
+++ b/src/main/scala/nl/knaw/dans/easy/pid/rest/PidRestService.scala
@@ -29,7 +29,7 @@ class PidRestService(implicit settings: Settings) extends ScalatraServlet with S
   val urns = PidGenerator.urnGenerator
   val dois = PidGenerator.doiGenerator
 
-  log.info("PID Generator Service running ...")
+  log.info("PID Generator REST Service running ...")
       
   get("/") {
     Ok("Persistent Identifier Generator running")

--- a/src/main/scala/nl/knaw/dans/easy/pid/rest/RestService.scala
+++ b/src/main/scala/nl/knaw/dans/easy/pid/rest/RestService.scala
@@ -33,12 +33,12 @@ class RestService(implicit settings: Settings) extends Service {
   // the actual PidRestService is mounted to the server in ScalatraBootstrap
 
   override def start() = {
-    log.info("Starting REST pid-generator service ...")
+    log.info("Starting REST pid-generator service...")
     server.start()
   }
 
   override def stop() = {
-    log.info("Stopping REST pid-generator service ...")
+    log.info("Stopping REST pid-generator service...")
     server.stop()
   }
 

--- a/src/main/scala/nl/knaw/dans/easy/pid/rest/RestService.scala
+++ b/src/main/scala/nl/knaw/dans/easy/pid/rest/RestService.scala
@@ -19,8 +19,11 @@ import nl.knaw.dans.easy.pid.{Service, Settings}
 import org.eclipse.jetty.server.Server
 import org.eclipse.jetty.servlet.ServletContextHandler
 import org.scalatra.servlet.ScalatraListener
+import org.slf4j.LoggerFactory
 
 class RestService(implicit settings: Settings) extends Service {
+  val log = LoggerFactory.getLogger(getClass)
+  log.info("Initializing REST pid-generator service ...")
 
   val server = new Server(settings.port)
   val context = new ServletContextHandler(ServletContextHandler.NO_SESSIONS)
@@ -30,15 +33,18 @@ class RestService(implicit settings: Settings) extends Service {
   // the actual PidRestService is mounted to the server in ScalatraBootstrap
 
   override def start() = {
+    log.info("Starting REST pid-generator service ...")
     server.start()
   }
 
   override def stop() = {
+    log.info("Stopping REST pid-generator service ...")
     server.stop()
   }
 
   override def destroy() = {
     server.destroy()
+    log.info("Service REST pid-generator stopped.")
   }
 }
 


### PR DESCRIPTION
fixes EASY-1138
#### When applied it will
- [x] rename `PidServiceStarter` to `ServiceStarter` to be equivalent to the other daemonized projects
- [x] bring initializing the logger into the `Daemon`'s `init` method
- [x] change the wording on the `init` method's info-log
- [x] report the exit-code from jsvc in the initd script
#### Where should the reviewer @DANS-KNAW/easy start?

`ServiceStarter.scala`
#### How should this be manually tested?

To test the initd script, cause an error at startup/init (for example by running in `hazelcast` mode and turning off the `easy-hazelcast` cluster) and see the result
#### related pull requests on github

| repo | PR |
| --- | --- |
| easy-ingest-flow | [PR#55](https://github.com/DANS-KNAW/easy-ingest-flow/pull/55) |
| easy-dtap | [PR#47](https://github.com/DANS-KNAW/easy-dtap/pull/47) |
| easy-hazelcast | [PR#3](https://github.com/DANS-KNAW/easy-hazelcast/pull/3) |
| easy-ingest-dispatcher | [PR#34](https://github.com/DANS-KNAW/easy-ingest-dispatcher/pull/34) |
