### PR TITLE
EASY-1398: Change the URN pattern

### DIFF
--- a/src/main/assembly/dist/cfg/application.properties
+++ b/src/main/assembly/dist/cfg/application.properties
@@ -6,7 +6,7 @@ pid-generator.database.password=changeme
 pid-generator.daemon.http.port=20140
 
 pid-generator.types.urn.namespace=urn:nbn:nl:ui:13-
-pid-generator.types.urn.dashPosition=4
+pid-generator.types.urn.dashPosition=2
 pid-generator.types.urn.firstSeed=1
 
 pid-generator.types.doi.namespace=10.5072/dans-


### PR DESCRIPTION
fixes EASY-1398

this is done because the seed got compromised. so in order to ensure uniqueness the pattern has been changed.

#### Where should the reviewer @DANS-KNAW/easy start?

