### PR TITLE
support for prefix/suffix notation of GET call

### DIFF
--- a/src/main/scala/nl/knaw/dans/easy/pid/PidGeneratorServlet.scala
+++ b/src/main/scala/nl/knaw/dans/easy/pid/PidGeneratorServlet.scala
@@ -31,7 +31,21 @@ class PidGeneratorServlet(app: PidGeneratorApp, configuration: Configuration) ex
 
   // GET /{doi|urn}/{...}
   get("/:type/:id") {
-    (params.get("type").flatMap(PidType.parse), params.get("id")) match {
+    doiExists(params.get("type").flatMap(PidType.parse), params.get("id"))
+  }
+
+  // GET /{doi|urn}/{...}/{...}
+  get("/:type/:prefix/:suffix") {
+    val pid = for {
+      prefix <- params.get("prefix")
+      suffix <- params.get("suffix")
+    } yield s"$prefix/$suffix"
+
+    doiExists(params.get("type").flatMap(PidType.parse), pid)
+  }
+
+  private def doiExists(maybePidType: Option[PidType], maybePid: Option[Pid]): ActionResult = {
+    (maybePidType, maybePid) match {
       case (Some(pidType), Some(pid)) => app.exists(pidType, pid)
         .map {
           case true => NoContent()

--- a/src/test/scala/nl/knaw/dans/easy/pid/PidGeneratorServletSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/pid/PidGeneratorServletSpec.scala
@@ -67,6 +67,28 @@ class PidGeneratorServletSpec extends TestSupportFixture
     }
   }
 
+  "GET /doi/<prefix>/<suffix>" should "return 204 when the DOI is present" in {
+    app.exists _ expects (DOI, "my-prefix/my-suffix") once() returning Success(true)
+    get("/doi/my-prefix/my-suffix") {
+      status shouldBe 204
+    }
+  }
+
+  it should "return 404 when the DOI is not present" in {
+    app.exists _ expects (DOI, "my-prefix/my-suffix") once() returning Success(false)
+    get("/doi/my-prefix/my-suffix") {
+      status shouldBe 404
+      body shouldBe "doi my-prefix/my-suffix doesn't exist"
+    }
+  }
+
+  it should "return 400 when an unknown PID type is requested" in {
+    get("/unknown/my-prefix/my-suffix") {
+      status shouldBe 400
+      body shouldBe "Usage: GET /{doi|urn}/{...}"
+    }
+  }
+
   "POST /create?type=doi" should "return the next DOI PID" in {
     (app.generate(_: PidType)) expects DOI once() returning Success("doi output")
     post("/create", ("type", "doi")) {


### PR DESCRIPTION
fixes EASY-1918

#### When applied it will
* add support for prefix/suffix notation of GET call

@DANS-KNAW/easy for review