### PR TITLE
EASY-2179: update scalatra

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.2-SNAPSHOT</version>
+        <version>6.0.2</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-pid-generator</artifactId>

--- a/pom.xml
+++ b/pom.xml
@@ -21,7 +21,7 @@
     <parent>
         <groupId>nl.knaw.dans.shared</groupId>
         <artifactId>dans-scala-app-project</artifactId>
-        <version>6.0.1</version>
+        <version>6.0.2-SNAPSHOT</version>
     </parent>
     <groupId>nl.knaw.dans.easy</groupId>
     <artifactId>easy-pid-generator</artifactId>
@@ -53,6 +53,10 @@
         <dependency>
             <groupId>org.scalacheck</groupId>
             <artifactId>scalacheck_2.12</artifactId>
+        </dependency>
+        <dependency>
+            <groupId>org.scalatestplus</groupId>
+            <artifactId>scalatestplus-scalacheck_2.12</artifactId>
         </dependency>
         <dependency>
             <groupId>org.scala-lang.modules</groupId>

--- a/src/test/scala/nl/knaw/dans/easy/pid/fixture/TestSupportFixture.scala
+++ b/src/test/scala/nl/knaw/dans/easy/pid/fixture/TestSupportFixture.scala
@@ -17,9 +17,11 @@ package nl.knaw.dans.easy.pid.fixture
 
 import better.files.File
 import better.files.File.currentWorkingDirectory
-import org.scalatest.{ BeforeAndAfterEach, FlatSpec, Inside, Matchers }
+import org.scalatest.{ BeforeAndAfterEach, Inside }
+import org.scalatest.flatspec.AnyFlatSpec
+import org.scalatest.matchers.should.Matchers
 
-trait TestSupportFixture extends FlatSpec with Matchers with Inside with BeforeAndAfterEach {
+trait TestSupportFixture extends AnyFlatSpec with Matchers with Inside with BeforeAndAfterEach {
 
   override def beforeEach(): Unit = {
     super.beforeEach()

--- a/src/test/scala/nl/knaw/dans/easy/pid/generator/PidFormatterSpec.scala
+++ b/src/test/scala/nl/knaw/dans/easy/pid/generator/PidFormatterSpec.scala
@@ -17,12 +17,13 @@ package nl.knaw.dans.easy.pid.generator
 
 import nl.knaw.dans.easy.pid.Seed
 import org.scalacheck.Gen
-import org.scalatest.prop.GeneratorDrivenPropertyChecks
-import org.scalatest.{ Matchers, PropSpec }
+import org.scalatest.matchers.should.Matchers
+import org.scalatest.propspec.AnyPropSpec
+import org.scalatestplus.scalacheck.ScalaCheckDrivenPropertyChecks
 
 import scala.language.postfixOps
 
-class PidFormatterSpec extends PropSpec with GeneratorDrivenPropertyChecks with Matchers {
+class PidFormatterSpec extends AnyPropSpec with ScalaCheckDrivenPropertyChecks with Matchers {
 
   def genMap(n: Int): Gen[Map[Char, Char]] = {
     Gen.mapOf(for {


### PR DESCRIPTION
fixes EASY-2179

#### When applied it will
* update parent POM version
* fix deprecation warnings
* add dependency `scalatestplus-scalacheck_2.12` to replace deprecated `GeneratorDrivenPropertyChecks`

#### Where should the reviewer @DANS-KNAW/easy start?

#### How should this be manually tested?

#### related pull requests on github
repo                       | PR                | Note
-------------------------- | ----------------- | ----
easy-                      | [PR#](PRlink)     |